### PR TITLE
Improve chat history

### DIFF
--- a/rdiodj/static/js/chat.js
+++ b/rdiodj/static/js/chat.js
@@ -104,8 +104,6 @@ chat.MessageHistoryList = Backbone.Firebase.Collection.extend({
   firebase: chat.firebaseMessagesRef
 });
 
-chat.messageHistory = new chat.MessageHistoryList();
-
 chat.UserMessageView = Backbone.View.extend({
   tagName: 'li',
 
@@ -213,7 +211,7 @@ R.ready(function() {
   });
 
   // we set up track change messages in rdiodj.js
-
+  chat.messageHistory = new chat.MessageHistoryList();
   var chatView = new chat.MessagesView();
 });
 


### PR DESCRIPTION
Here's a slightly kludgey attempt at improving chat history. Sometimes we get the chat history back from firebase before we set up the event to listen to those messages, so they don't go through. This initializes the history _right_ before the view so there's less time for the data to come in, but I'm sure someone more proficient in JS can improve it.