### PR TITLE
Added an endpoint to create a valid Firebase user auth token

### DIFF
--- a/rdiodj/urls.py
+++ b/rdiodj/urls.py
@@ -19,6 +19,7 @@ urlpatterns = patterns('',
 
     url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
     url(r'^admin/', include(admin.site.urls)),
+    url(r'^create-auth/', 'rdiodj.views.createauthtoken')
 )
 
 

--- a/rdiodj/views.py
+++ b/rdiodj/views.py
@@ -231,15 +231,13 @@ def createauthtoken(request):
     response = None
 
     rdio_user_key = request.GET.get('userKey')
-    if rdio_user_key is None:
-        response = {"error": "userKey is a required GET param"}
-
-    else:
-
+    if rdio_user_key:
         custom_data = {'rdio_user_key': rdio_user_key}
         options = {'debug': settings.DEBUG}
         firebase_token = create_token(settings.FIREBASE_TOKEN, custom_data, options)
         response = { "token": firebase_token }
+    else:
+        response = {"error": "userKey is a required GET param"}
 
     return HttpResponse(json.dumps(response), content_type = "application/json")
 

--- a/rdiodj/views.py
+++ b/rdiodj/views.py
@@ -11,6 +11,7 @@ from django.http import HttpResponse
 import subprocess
 import psutil
 import os
+from firebase_token_generator import create_token
 
 def home(request):
     c = RequestContext(request, {
@@ -225,6 +226,22 @@ def ajax(request):
 }
 
     return HttpResponse(json.dumps(data), content_type = "application/json")
+
+def createauthtoken(request):
+    response = None
+
+    rdio_user_key = request.GET.get('userKey')
+    if rdio_user_key is None:
+        response = {"error": "userKey is a required GET param"}
+
+    else:
+
+        custom_data = {'rdio_user_key': rdio_user_key}
+        options = {'debug': settings.DEBUG}
+        firebase_token = create_token(settings.FIREBASE_TOKEN, custom_data, options)
+        response = { "token": firebase_token }
+
+    return HttpResponse(json.dumps(response), content_type = "application/json")
 
 def make_room_daemon(room_name):
   child_processes = psutil.Process(os.getpid()).get_children()


### PR DESCRIPTION
This is my first Python thing.  Tabs are hard.

It feels weird to put an API endpoint in a file called *"views.py"*, but I did it anyway because I don't know where else to put it.
The Django documentation states that I can specify a *status_code* in the *HttpResponse* but it doesn't seem to work?  It'd be nice to throw a legit HTTP 400 on an error.

Thank you for your consideration.  I hope this pull request finds you well.